### PR TITLE
Initialize React Vite game scaffold

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite React Game</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "react-vite-pipe-dream",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,15 @@
+nav ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  gap: 1rem;
+}
+
+nav a {
+  color: #0366d6;
+  text-decoration: none;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,26 @@
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import Welcome from './pages/Welcome';
+import GameBoard from './pages/GameBoard';
+import Settings from './pages/Settings';
+import './App.css';
+
+function App() {
+  return (
+    <Router>
+      <nav>
+        <ul>
+          <li><Link to="/">Welcome</Link></li>
+          <li><Link to="/board">Game Board</Link></li>
+          <li><Link to="/settings">Settings</Link></li>
+        </ul>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Welcome />} />
+        <Route path="/board" element={<GameBoard />} />
+        <Route path="/settings" element={<Settings />} />
+      </Routes>
+    </Router>
+  );
+}
+
+export default App;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,9 @@
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+#root {
+  padding: 1rem;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/pages/GameBoard.css
+++ b/src/pages/GameBoard.css
@@ -1,0 +1,13 @@
+.board {
+  display: grid;
+  grid-template-columns: repeat(24, 20px);
+  grid-template-rows: repeat(24, 20px);
+  gap: 2px;
+}
+
+.square {
+  width: 20px;
+  height: 20px;
+  background-color: #eee;
+  border: 1px solid #ccc;
+}

--- a/src/pages/GameBoard.jsx
+++ b/src/pages/GameBoard.jsx
@@ -1,0 +1,16 @@
+import './GameBoard.css';
+
+function GameBoard() {
+  const size = 24;
+  const squares = Array.from({ length: size * size }, (_, i) => i);
+
+  return (
+    <div className="board">
+      {squares.map((num) => (
+        <div key={num} className="square"></div>
+      ))}
+    </div>
+  );
+}
+
+export default GameBoard;

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,0 +1,10 @@
+function Settings() {
+  return (
+    <div>
+      <h1>Settings</h1>
+      <p>Configure your preferences here.</p>
+    </div>
+  );
+}
+
+export default Settings;

--- a/src/pages/Welcome.jsx
+++ b/src/pages/Welcome.jsx
@@ -1,0 +1,10 @@
+function Welcome() {
+  return (
+    <div>
+      <h1>Welcome to the Game!</h1>
+      <p>Press Game Board to start playing.</p>
+    </div>
+  );
+}
+
+export default Welcome;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- set up a minimal Vite/React project
- add routing with Welcome, GameBoard, and Settings pages
- implement a 24 x 24 game board
- provide basic styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688acaae428c832fb3cb0f337fc8a74d